### PR TITLE
Circumflex

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,8 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
-        platform: [ubuntu-20.04]
+        node-version: [18.x, 20.x, 21.x]
+        platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}
 
@@ -22,15 +22,15 @@ jobs:
       OS: ${{ matrix.os }}
       NODE: ${{ matrix.node-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: coverage/lcov.info
           env_vars: OS,NODE

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,9 +61,9 @@ const visit = peggy.compiler.visitor.build({
     return new Choice(0, ...node.alternatives.map(a => visit(a, context)));
   },
   class(node) {
-    const parts = node.parts.map(([start, end]) => end
+    const parts = node.parts.map(([start, end]) => (end
       ? `${regexpClassEscape(start)}-${regexpClassEscape(end)}`
-      : regexpClassEscape(start));
+      : regexpClassEscape(start)));
     return new Terminal(`[${parts.join("")}]`);
   },
   literal(node) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,10 +64,10 @@ const visit = peggy.compiler.visitor.build({
     const parts = node.parts.map(([start, end]) => (end
       ? `${regexpClassEscape(start)}-${regexpClassEscape(end)}`
       : regexpClassEscape(start)));
-    return new Terminal(`[${parts.join("")}]`);
+    return new Terminal(`[${node.inverted ? "^" : ""}${parts.join("")}]${node.ignoreCase ? "i" : ""}`);
   },
   literal(node) {
-    return new Terminal(`"${stringEscape(node.value)}"`);
+    return new Terminal(`"${stringEscape(node.value)}"${node.ignoreCase ? "i" : ""}`);
   },
   one_or_more(node, context) {
     return new OneOrMore(visit(node.expression, context));

--- a/package.json
+++ b/package.json
@@ -27,21 +27,21 @@
   "repository": "peggyjs/peggy-tracks",
   "bugs": "https://github.com/peggyjs/peggy-tracks/issues",
   "dependencies": {
-    "commander": "^8.1.0",
-    "peggy": "^1.2.0"
+    "commander": "^11.1.0",
+    "peggy": "^3.0.2"
   },
   "engines": {
     "node": ">=16"
   },
   "devDependencies": {
-    "@peggyjs/eslint-config": "^0.0.2",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^4.30.0",
-    "@typescript-eslint/parser": "^4.30.0",
-    "ava": "^4.0.0-alpha.2",
-    "c8": "^7.8.0",
+    "@peggyjs/eslint-config": "^3.0.6",
+    "@types/node": "^20.8.10",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ava": "^5.3.1",
+    "c8": "^8.0.1",
     "chokidar-cli": "^3.0.0",
-    "eslint": "^7.32.0",
-    "typescript": "^4.4.2"
+    "eslint": "^8.52.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/types/lib/index.d.ts
+++ b/types/lib/index.d.ts
@@ -34,4 +34,6 @@ export type TrackOptions = {
      */
     parserOptions: object;
 };
-import { ComplexDiagram, Diagram, defaultCSS } from "../vendor/railroad-diagrams/railroad.js";
+import { Diagram } from "../vendor/railroad-diagrams/railroad.js";
+import { ComplexDiagram } from "../vendor/railroad-diagrams/railroad.js";
+import { defaultCSS } from "../vendor/railroad-diagrams/railroad.js";

--- a/types/vendor/railroad-diagrams/railroad.d.ts
+++ b/types/vendor/railroad-diagrams/railroad.d.ts
@@ -1,15 +1,15 @@
 export default funcs;
 export namespace Options {
-    const DEBUG: boolean;
-    const VS: number;
-    const AR: number;
-    const DIAGRAM_CLASS: string;
-    const STROKE_ODD_PIXEL_LENGTH: boolean;
-    const INTERNAL_ALIGNMENT: string;
-    const CHAR_WIDTH: number;
-    const COMMENT_CHAR_WIDTH: number;
+    let DEBUG: boolean;
+    let VS: number;
+    let AR: number;
+    let DIAGRAM_CLASS: string;
+    let STROKE_ODD_PIXEL_LENGTH: boolean;
+    let INTERNAL_ALIGNMENT: string;
+    let CHAR_WIDTH: number;
+    let COMMENT_CHAR_WIDTH: number;
 }
-export const defaultCSS: "\n\tsvg {\n\t\tbackground-color: hsl(30,20%,95%);\n\t}\n\tpath {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: rgba(0,0,0,0);\n\t}\n\ttext {\n\t\tfont: bold 14px monospace;\n\t\ttext-anchor: middle;\n\t\twhite-space: pre;\n\t}\n\ttext.diagram-text {\n\t\tfont-size: 12px;\n\t}\n\ttext.diagram-arrow {\n\t\tfont-size: 16px;\n\t}\n\ttext.label {\n\t\ttext-anchor: start;\n\t}\n\ttext.comment {\n\t\tfont: italic 12px monospace;\n\t}\n\tg.non-terminal text {\n\t\t/*font-style: italic;*/\n\t}\n\trect {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: hsl(120,100%,90%);\n\t}\n\trect.group-box {\n\t\tstroke: gray;\n\t\tstroke-dasharray: 10 5;\n\t\tfill: none;\n\t}\n\tpath.diagram-text {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: white;\n\t\tcursor: help;\n\t}\n\tg.diagram-text:hover path.diagram-text {\n\t\tfill: #eee;\n\t}";
+export const defaultCSS: "\n\tsvg {\n\t\tbackground-color: hsl(30,20%,95%);\n\t}\n\tpath {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: rgba(0,0,0,0);\n\t}\n\ttext {\n\t\tfont: bold 14px monospace;\n\t\ttext-anchor: middle;\n\t\twhite-space: pre;\n\t}\n\ttext.diagram-text {\n\t\tfont-size: 12px;\n\t}\n\ttext.diagram-arrow {\n\t\tfont-size: 16px;\n\t}\n\ttext.label {\n\t\ttext-anchor: start;\n\t}\n\ttext.comment {\n\t\tfont: italic 12px monospace;\n\t}\n\tg.non-terminal text {\n\t\t/*font-style: italic;*/\n\t}\n\trect {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: hsl(120,100%,90%);\n\t}\n\trect.group-box {\n\t\tstroke: gray;\n\t\tstroke-dasharray: 10 5;\n\t\tfill: none;\n\t}\n\tpath.diagram-text {\n\t\tstroke-width: 3;\n\t\tstroke: black;\n\t\tfill: white;\n\t\tcursor: help;\n\t}\n\t.decision path {\n    fill: #ccc;\n  }\n\tg.diagram-text:hover path.diagram-text {\n\t\tfill: #eee;\n\t}";
 export class FakeSVG {
     constructor(tagName: any, attrs: any, text: any);
     children: any;
@@ -23,16 +23,17 @@ export class FakeSVG {
 }
 export class Path extends FakeSVG {
     constructor(x: any, y: any);
-    m(x: any, y: any): Path;
-    h(val: any): Path;
-    right(val: any): Path;
-    left(val: any): Path;
-    v(val: any): Path;
-    down(val: any): Path;
-    up(val: any): Path;
-    arc(sweep: any): Path;
-    arc_8(start: any, dir: any): Path;
-    l(x: any, y: any): Path;
+    m(x: any, y: any): this;
+    h(val: any): this;
+    right(val: any): this;
+    left(val: any): this;
+    v(val: any): this;
+    down(val: any): this;
+    up(val: any): this;
+    arc(sweep: any): this;
+    arc_8(start: any, dir: any): this;
+    l(x: any, y: any): this;
+    format(): this;
 }
 export class DiagramMultiContainer extends FakeSVG {
     constructor(tagName: any, items: any, attrs: any, text: any);
@@ -45,6 +46,8 @@ export class Diagram extends DiagramMultiContainer {
     height: number;
     width: number;
     formatted: boolean;
+    format(paddingt: any, paddingr: any, paddingb: any, paddingl: any): this;
+    toString(): any;
     toStandalone(style: any): any;
 }
 export class ComplexDiagram extends FakeSVG {
@@ -57,6 +60,7 @@ export class Sequence extends DiagramMultiContainer {
     down: number;
     height: number;
     width: number;
+    format(x: any, y: any, width: any): this;
 }
 export class Stack extends DiagramMultiContainer {
     constructor(...items: any[]);
@@ -65,6 +69,7 @@ export class Stack extends DiagramMultiContainer {
     up: any;
     down: any;
     height: number;
+    format(x: any, y: any, width: any): this;
 }
 export class OptionalSequence extends DiagramMultiContainer {
     constructor(...items: any[]);
@@ -73,6 +78,7 @@ export class OptionalSequence extends DiagramMultiContainer {
     up: number;
     height: any;
     down: any;
+    format(x: any, y: any, width: any): this;
 }
 export class AlternatingSequence extends DiagramMultiContainer {
     constructor(...items: any[]);
@@ -81,6 +87,7 @@ export class AlternatingSequence extends DiagramMultiContainer {
     down: any;
     height: number;
     width: number;
+    format(x: any, y: any, width: any): this;
 }
 export class Choice extends DiagramMultiContainer {
     constructor(normal: any, ...items: any[]);
@@ -89,6 +96,7 @@ export class Choice extends DiagramMultiContainer {
     height: any;
     up: any;
     down: any;
+    format(x: any, y: any, width: any): this;
 }
 export class HorizontalChoice extends DiagramMultiContainer {
     constructor(...items: any[]);
@@ -99,6 +107,7 @@ export class HorizontalChoice extends DiagramMultiContainer {
     up: number;
     _lowerTrack: number;
     down: number;
+    format(x: any, y: any, width: any): this;
 }
 export class MultipleChoice extends DiagramMultiContainer {
     constructor(normal: any, type: any, ...items: any[]);
@@ -110,6 +119,7 @@ export class MultipleChoice extends DiagramMultiContainer {
     up: any;
     down: any;
     height: any;
+    format(x: any, y: any, width: any): this;
 }
 export class Optional extends FakeSVG {
     constructor(item: any, skip: any);
@@ -123,6 +133,7 @@ export class OneOrMore extends FakeSVG {
     up: any;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class ZeroOrMore extends FakeSVG {
 }
@@ -136,6 +147,7 @@ export class Group extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class Start extends FakeSVG {
     constructor({ type, label }?: {
@@ -148,6 +160,7 @@ export class Start extends FakeSVG {
     down: number;
     type: string;
     label: string;
+    format(x: any, y: any): this;
 }
 export class End extends FakeSVG {
     constructor({ type }?: {
@@ -158,6 +171,7 @@ export class End extends FakeSVG {
     up: number;
     down: number;
     type: string;
+    format(x: any, y: any): this;
 }
 export class Terminal extends FakeSVG {
     constructor(text: any, { href, title, cls }?: {
@@ -174,6 +188,7 @@ export class Terminal extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class NonTerminal extends FakeSVG {
     constructor(text: any, { href, title, cls }?: {
@@ -190,6 +205,24 @@ export class NonTerminal extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
+}
+export class Decision extends FakeSVG {
+    constructor(text: any, { href, title, cls }?: {
+        href?: any;
+        title?: any;
+        cls?: string;
+    });
+    text: string;
+    href: any;
+    title: any;
+    cls: string;
+    width: number;
+    height: number;
+    up: number;
+    down: number;
+    needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class Comment extends FakeSVG {
     constructor(text: any, { href, title, cls }?: {
@@ -206,6 +239,7 @@ export class Comment extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class Skip extends FakeSVG {
     constructor();
@@ -214,6 +248,7 @@ export class Skip extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 export class Block extends FakeSVG {
     constructor({ width, up, height, down, needsSpace }?: {
@@ -228,6 +263,7 @@ export class Block extends FakeSVG {
     up: number;
     down: number;
     needsSpace: boolean;
+    format(x: any, y: any, width: any): this;
 }
 declare namespace funcs {
     function Diagram(...args: any[]): Diagram;
@@ -247,6 +283,7 @@ declare namespace funcs {
     function End(...args: any[]): End;
     function Terminal(...args: any[]): Terminal;
     function NonTerminal(...args: any[]): NonTerminal;
+    function Decision(...args: any[]): Decision;
     function Comment(...args: any[]): Comment;
     function Skip(...args: any[]): Skip;
     function Block(...args: any[]): Block;


### PR DESCRIPTION
Fixes #12.

ensures that `[^abc]i` and `"abc"i` get rendered as such.